### PR TITLE
When finding the tally point, move one block back.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3541,6 +3541,14 @@ bool ReorganizeChain(CTxDB& txdb, unsigned &cnt_dis, unsigned &cnt_con, CBlock &
         }
     }
 
+    /* now that we are at a tally point, move to the previous block if possible.
+     * This will cause the next tally to move back to the previous
+     * TALLY_GRANULARITY. Without this we would reject blocks if we try to
+     * reorganize to a point between a superblock and a tally point.
+     */
+    if(pcommon->pprev)
+        pcommon = pcommon->pprev;
+
     /* disconnect blocks */
     if(pcommon!=pindexBest)
     {


### PR DESCRIPTION
This fixes issues where there are superblocks between tally points.

I'm not sure if this is the correct way to approach the problem but I believe that is why me, quez and startail all failed to reorganize to a block (1151618) which was a superblock between tally points (1151610 and 1151620). The staking node hadn't tallied on 1151610 yet.

Edit: This is definitely not the way to solve the problem. With this PR it takes ~5 seconds to process one block, as if it scanned the entire chain.

Edit2: Need to take another look at those assumptions as they may be invalid.